### PR TITLE
fix: fix macros resolution

### DIFF
--- a/common/src/id.rs
+++ b/common/src/id.rs
@@ -14,7 +14,7 @@ pub use soar_token::ID as SOAR_TOKEN;
 mod soar_token {
     use super::*;
     #[cfg(feature = "mainnet")]
-    declare_id!("");
+    declare_id!("6LYGMPnpZnCh4tPGDCdUREmig5SA5NPj2BssYhCerZcP");
     #[cfg(not(feature = "mainnet"))]
     declare_id!("6LYGMPnpZnCh4tPGDCdUREmig5SA5NPj2BssYhCerZcP");
 }
@@ -28,7 +28,7 @@ mod staking_program {
 pub use rewards_program::ID as REWARDS_PROGRAM;
 mod rewards_program {
     use super::*;
-    declare_id!("");
+    declare_id!("A9ckgy4rXMUnupZR3CcmfXnQceE1NbXvthjyKUEuDPKj");
 }
 
 pub use authority::ID as AUTHORITY;

--- a/common/src/macros.rs
+++ b/common/src/macros.rs
@@ -19,7 +19,7 @@
  #[macro_export]
  macro_rules! transfer_tokens_to_vault {
      ($accounts: expr, $amount: expr) => {
-         cpi::transfer_tokens(
+        soarchain_common::cpi::transfer_tokens(
              $accounts.token_program.to_account_info(),
              $accounts.user.to_account_info(),
              $accounts.vault.to_account_info(),
@@ -33,7 +33,7 @@
  #[macro_export]
  macro_rules! transfer_tokens_from_vault {
      ($accounts: expr, $to: ident, $seeds: expr, $amount: expr) => {
-         cpi::transfer_tokens(
+        soarchain_common::cpi::transfer_tokens(
              $accounts.token_program.to_account_info(),
              $accounts.vault.to_account_info(),
              $accounts.$to.to_account_info(),
@@ -47,7 +47,7 @@
  #[macro_export]
  macro_rules! close_vault {
      ($accounts: expr, $seeds: expr) => {
-         cpi::close_token_account(
+        soarchain_common::cpi::close_token_account(
              $accounts.token_program.to_account_info(),
              $accounts.vault.to_account_info(),
              $accounts.authority.to_account_info(),
@@ -58,12 +58,12 @@
  }
  
  #[macro_export]
- macro_rules! transfer_fee {
+ macro_rules! transfer_funds {
      ($accounts: expr, $from: ident, $authority: ident, $seeds: expr, $amount: expr) => {
-         soarchain_rewards::cpi::add_fee(
+         soarchain_rewards::cpi::add_funds(
              CpiContext::new_with_signer(
                  $accounts.rewards_program.to_account_info(),
-                 AddFee {
+                 AddFunds {
                      user: $accounts.$from.to_account_info(),
                      reflection: $accounts.rewards_reflection.to_account_info(),
                      vault: $accounts.rewards_vault.to_account_info(),


### PR DESCRIPTION
Updated the macros to use the fully qualified path to cpi functions from soarchain-common. Replace instances of cpi:: with crate::cpi:: or soarchain_common::cpi::.